### PR TITLE
Fixes #12 - copyJarToDockerDir task will use name of JAR file from ja…

### DIFF
--- a/src/main/groovy/pl/greenpath/gradle/DockerPlugin.groovy
+++ b/src/main/groovy/pl/greenpath/gradle/DockerPlugin.groovy
@@ -32,9 +32,7 @@ class DockerPlugin implements Plugin<Project> {
 
     project.task('generateDockerfile', type: GenerateDockerfileTask)
     project.task('copyJarToDockerDir', type: Copy, dependsOn: 'assemble') {
-      from(new File(project.buildDir, 'libs')) {
-        include "${project.name}-${project.version}.jar"
-      }
+      from { project.jar.archivePath }
       into new File(project.buildDir, 'docker')
     }
     project.task('dockerStop', type: DockerStopTask)

--- a/src/test/groovy/pl/greenpath/gradle/task/CopyJarToDockerDirTest.groovy
+++ b/src/test/groovy/pl/greenpath/gradle/task/CopyJarToDockerDirTest.groovy
@@ -1,0 +1,35 @@
+package pl.greenpath.gradle.task
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.Copy
+import org.gradle.jvm.tasks.Jar
+import org.gradle.testfixtures.ProjectBuilder
+import pl.greenpath.gradle.DockerPlugin
+import spock.lang.Specification
+
+class CopyJarToDockerDirTest extends Specification {
+
+  Project rootProject
+
+  def setup() {
+    rootProject = ProjectBuilder.builder().withName('testProject').build()
+    def dockerPlugin = new DockerPlugin()
+    rootProject.pluginManager.apply('java')
+    dockerPlugin.apply(rootProject)
+  }
+
+  def "should copy JAR file named based on JAR task configuration when copyJarToDockerDir task is run"() {
+    given:
+    rootProject.jar.baseName = 'testName123'
+    rootProject.jar.version = '1.1.1'
+    Copy task = rootProject.getTasksByName("copyJarToDockerDir", false).first()
+    def jarFilePath = rootProject.buildDir.toPath().resolve('docker').resolve('testName123-1.1.1.jar')
+    when:
+    Jar jarTask = rootProject.getTasksByName('jar', true).first()
+    jarTask.execute()
+    task.execute()
+    then:
+    jarFilePath.toFile().exists()
+
+  }
+}


### PR DESCRIPTION
…r task configuration, instead of assuming it to be "${project.name}-${project.version}.jar"

For issue #12 
